### PR TITLE
Remove hard dependency on DropWizard Metrics backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,35 @@ Example of including ST-Metrics in your Maven project:
 </dependency>
 ```
 
+ST-Metrics can make use to two different backends to send timing metrics to: DropWizard Metrics or Spring
+Boot Actuator. Depending on which of these you'd like to use, you may have to add another include to pull
+in the relevant package.
+
+DropWizard Metrics
+
+``` xml
+<dependency>
+    <groupId>io.dropwizard.metrics</groupId>
+    <artifactId>metrics-core</artifactId>
+    <version>x.y.z</version>
+</dependency>
+```
+
+Spring Boot Actuator:
+
+``` xml
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-actuator</artifactId>
+    <version>x.y.z</version>
+</dependency>
+```
+
 ## Usage
 
 Configuring st-metrics should be as simple as adding a new `@Bean` to your existing application `@Configuration`.
+
+An example of using the DropWizard Metrics backend.
 
 ``` java
 package com.example.myapp;
@@ -30,6 +56,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.smartertravel.metrics.aop.TimingAspect;
+import com.smartertravel.metrics.aop.backend.MetricSinkDropWizard;
 
 @Configuration
 public class MyApplicationConfig {
@@ -41,7 +68,35 @@ public class MyApplicationConfig {
     
     @Bean
     public TimingAspect timingAspect() {
-        return new TimingAspect(metricRegistry);
+        return new TimingAspect(new MetricSinkDropWizard(metricRegistry));
+    }
+}
+```
+
+An example of using the Spring Boot Actuator backend.
+
+``` java
+package com.example.myapp;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.metrics.GaugeService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.smartertravel.metrics.aop.TimingAspect;
+import com.smartertravel.metrics.aop.backend.MetricSinkSpringBoot;
+
+@Configuration
+public class MyApplicationConfig {
+
+    // Your other configuration would be here.
+    
+    @Autowired
+    private GaugeService gaugeService;
+    
+    @Bean
+    public TimingAspect timingAspect() {
+        return new TimingAspect(new MetricSinkSpringBoot(gaugeService));
     }
 }
 ```
@@ -67,5 +122,6 @@ public class UserDaoMysql implements UserDao {
 
 Now, on every call of `UserDaoMysql.getUserById()` you should see timing results available as part
 of the metrics for your application, available at http://localhost:8080/metrics by default.
+
 
 For more advanced usage, check out the [docs](http://eng.smartertravel.com/st-metrics/).

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/smartertravel/metrics/aop/backend/MetricSink.java
+++ b/src/main/java/com/smartertravel/metrics/aop/backend/MetricSink.java
@@ -1,0 +1,28 @@
+package com.smartertravel.metrics.aop.backend;
+
+import com.smartertravel.metrics.aop.TimingAspect;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Interface for recording method timing information under a particular name.
+ * <p>
+ * This interface exists to separate method timing done by {@link TimingAspect} from
+ * the underlying system or library actually used to record the timing. For example,
+ * in a Spring Boot 1.3+ project, we would use {@code GaugeService} for recording timings
+ * and have Spring push these timings to various backends (Statsd, JMX, Redis, etc.). In
+ * a non-Spring Boot project, we could use the DropWizard Metrics {@code MetricRegistry}
+ * library to push timings to various backends that it supports (Graphite, JMX, logs, etc.).
+ */
+public interface MetricSink {
+
+    /**
+     * Submit execution time of a method to some metrics aggregator backend.
+     *
+     * @param name     Full key for the metrics to be recorded under
+     * @param duration Total method execution time
+     * @param unit     Unit for method execution time
+     */
+    void time(String name, long duration, TimeUnit unit);
+
+}

--- a/src/main/java/com/smartertravel/metrics/aop/backend/MetricSinkDropWizard.java
+++ b/src/main/java/com/smartertravel/metrics/aop/backend/MetricSinkDropWizard.java
@@ -1,0 +1,24 @@
+package com.smartertravel.metrics.aop.backend;
+
+import com.codahale.metrics.MetricRegistry;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Implementation of a {@link MetricSink} that writes to a DropWizard Metrics
+ * {@link MetricRegistry} instance.
+ */
+public class MetricSinkDropWizard implements MetricSink {
+
+    private final MetricRegistry registry;
+
+    public MetricSinkDropWizard(MetricRegistry registry) {
+        this.registry = Objects.requireNonNull(registry);
+    }
+
+    @Override
+    public void time(String name, long duration, TimeUnit unit) {
+        registry.timer(name).update(duration, unit);
+    }
+}

--- a/src/main/java/com/smartertravel/metrics/aop/backend/MetricSinkSpringBoot.java
+++ b/src/main/java/com/smartertravel/metrics/aop/backend/MetricSinkSpringBoot.java
@@ -1,0 +1,24 @@
+package com.smartertravel.metrics.aop.backend;
+
+import org.springframework.boot.actuate.metrics.GaugeService;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Implementation of a {@link MetricSink} that writes to a Spring Boot Actuator
+ * {@link GaugeService} instance.
+ */
+public class MetricSinkSpringBoot implements MetricSink {
+
+    private final GaugeService gaugeService;
+
+    public MetricSinkSpringBoot(GaugeService gaugeService) {
+        this.gaugeService = Objects.requireNonNull(gaugeService);
+    }
+
+    @Override
+    public void time(String name, long duration, TimeUnit unit) {
+        gaugeService.submit(name, unit.toMillis(duration));
+    }
+}

--- a/src/site/markdown/changes.md
+++ b/src/site/markdown/changes.md
@@ -4,6 +4,11 @@ The ST-Metrics library makes use of [Semantic versioning](http://semver.org/). C
 each release of the library are listed below along with an indication if they are breaking changes
 or not.
 
+### [v0.2.0](https://github.com/smarter-travel-media/st-metrics/tree/master) - Future release
+* **Breaking change**  - ``TimingAspect`` is now metric backend agnostic to allow use of DropWizard
+  Metrics or Spring Boot Actuator for publishing method timings. As a result the constructor of 
+  ``TimingAspect`` now accepts an interface that abstracts away the underlying metrics aggregator.
+
 ### [v0.1.1](https://github.com/smarter-travel-media/st-metrics/tree/st-metrics-0.1.1) - 2015-07-07
 * Documentation fixes and updates
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -17,9 +17,35 @@ Example of including ST-Metrics in your Maven project:
 </dependency>
 ```
 
+ST-Metrics can make use to two different backends to send timing metrics to: DropWizard Metrics or Spring
+Boot Actuator. Depending on which of these you'd like to use, you may have to add another include to pull
+in the relevant package.
+
+DropWizard Metrics
+
+``` xml
+<dependency>
+    <groupId>io.dropwizard.metrics</groupId>
+    <artifactId>metrics-core</artifactId>
+    <version>x.y.z</version>
+</dependency>
+```
+
+Spring Boot Actuator:
+
+``` xml
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-actuator</artifactId>
+    <version>x.y.z</version>
+</dependency>
+```
+
 ### Usage
 
 Configuring st-metrics should be as simple as adding a new `@Bean` to your existing application `@Configuration`.
+
+An example of using the DropWizard Metrics backend.
 
 ``` java
 package com.example.myapp;
@@ -30,6 +56,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.smartertravel.metrics.aop.TimingAspect;
+import com.smartertravel.metrics.aop.backend.MetricSinkDropWizard;
 
 @Configuration
 public class MyApplicationConfig {
@@ -41,7 +68,35 @@ public class MyApplicationConfig {
     
     @Bean
     public TimingAspect timingAspect() {
-        return new TimingAspect(metricRegistry);
+        return new TimingAspect(new MetricSinkDropWizard(metricRegistry));
+    }
+}
+```
+
+An example of using the Spring Boot Actuator backend.
+
+``` java
+package com.example.myapp;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.metrics.GaugeService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.smartertravel.metrics.aop.TimingAspect;
+import com.smartertravel.metrics.aop.backend.MetricSinkSpringBoot;
+
+@Configuration
+public class MyApplicationConfig {
+
+    // Your other configuration would be here.
+    
+    @Autowired
+    private GaugeService gaugeService;
+    
+    @Bean
+    public TimingAspect timingAspect() {
+        return new TimingAspect(new MetricSinkSpringBoot(gaugeService));
     }
 }
 ```

--- a/src/site/markdown/migration.md
+++ b/src/site/markdown/migration.md
@@ -1,0 +1,43 @@
+## Migration
+
+Notable changes required to upgrade to newer versions of ST-Metrics are detailed below.
+
+### v0.1.0 to v0.2.0
+
+* To continue to make use of the DropWizard Metrics backend, the declaration of the ``TimingAspect``
+  bean should be changed to match the way the aspect below is instantiated.
+  
+```java
+@Configuration
+public class MyApplicationConfig {
+
+    // Your other configuration would be here.
+    
+    @Autowired
+    private MetricRegistry metricRegistry;
+
+    @Bean
+    public TimingAspect myTimingAspect() {
+        return new TimingAspect(new MetricSinkDropWizard(metricRegistry));
+    }
+}
+```
+
+* To switch to using the Spring Boot Actuator backend, the declaration of the ``TimingAspect``
+  bean to should be changed to match the way the aspect below is instantiated.
+
+```java
+@Configuration
+public class MyApplicationConfig {
+
+    // Your other configuration would be here.
+    
+    @Autowired
+    private GaugeService gaugeService;
+
+    @Bean
+    public TimingAspect myTimingAspect() {
+        return new TimingAspect(new MetricSinkSpringBoot(gaugeService));
+    }
+}
+```

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -28,6 +28,7 @@
       <item name="About" href="index.html"/>
       <item name="Usage" href="usage.html"/>
       <item name="API" href="apidocs/index.html"/>
+      <item name="Migration" href="migration.html"/>
       <item name="Development" href="development.html"/>
       <item name="Changelog" href="changes.html"/>
     </menu>

--- a/src/test/java/com/smartertravel/metrics/aop/TimingAspectTest.java
+++ b/src/test/java/com/smartertravel/metrics/aop/TimingAspectTest.java
@@ -3,12 +3,15 @@ package com.smartertravel.metrics.aop;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.smartertravel.metrics.aop.TimingAspect.DefaultKeyGenerator;
+import com.smartertravel.metrics.aop.backend.MetricSinkDropWizard;
+import com.smartertravel.metrics.aop.backend.MetricSinkSpringBoot;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.Signature;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.boot.actuate.metrics.GaugeService;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -60,6 +63,9 @@ public class TimingAspectTest {
     private MetricRegistry metricRegistry;
 
     @Mock
+    private GaugeService gaugeService;
+
+    @Mock
     private Timer timer;
 
     @Test
@@ -86,7 +92,7 @@ public class TimingAspectTest {
     }
 
     @Test
-    public void testPerformanceLog() throws Throwable {
+    public void testPerformanceLogDropWizard() throws Throwable {
         final UserDaoHystrix dao = new UserDaoHystrix();
         final Method method = dao.getClass().getMethod("userExists", String.class);
         final Timed[] annotations = method.getAnnotationsByType(Timed.class);
@@ -96,7 +102,7 @@ public class TimingAspectTest {
         when(signature.getName()).thenReturn("userExists");
         when(metricRegistry.timer(eq("timer.UserDaoHystrix.userExists"))).thenReturn(timer);
 
-        final TimingAspect aspect = new TimingAspect(metricRegistry);
+        final TimingAspect aspect = new TimingAspect(new MetricSinkDropWizard(metricRegistry));
         final Object result = aspect.performanceLog(joinPoint, dao, annotations[0]);
 
         assertNotNull("Expected non-null result type", result);
@@ -105,7 +111,7 @@ public class TimingAspectTest {
     }
 
     @Test
-    public void testPerformanceLogWithException() throws Throwable {
+    public void testPerformanceLogDropWizardWithException() throws Throwable {
         final UserDaoHystrix dao = new UserDaoHystrix();
         final Method method = dao.getClass().getMethod("userExists", String.class);
         final Timed[] annotations = method.getAnnotationsByType(Timed.class);
@@ -115,7 +121,7 @@ public class TimingAspectTest {
         when(signature.getName()).thenReturn("userExists");
         when(metricRegistry.timer(eq("timer.UserDaoHystrix.userExists"))).thenReturn(timer);
 
-        final TimingAspect aspect = new TimingAspect(metricRegistry);
+        final TimingAspect aspect = new TimingAspect(new MetricSinkDropWizard(metricRegistry));
         IOException err = null;
 
         try {
@@ -126,5 +132,46 @@ public class TimingAspectTest {
 
         assertNotNull("Expected exception to be raised while calling join point", err);
         verify(timer).update(anyLong(), eq(TimeUnit.NANOSECONDS));
+    }
+
+    @Test
+    public void testPerformanceLogSpringBoot() throws Throwable {
+        final UserDaoHystrix dao = new UserDaoHystrix();
+        final Method method = dao.getClass().getMethod("userExists", String.class);
+        final Timed[] annotations = method.getAnnotationsByType(Timed.class);
+
+        when(joinPoint.proceed()).thenReturn(true);
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.getName()).thenReturn("userExists");
+
+        final TimingAspect aspect = new TimingAspect(new MetricSinkSpringBoot(gaugeService));
+        final Object result = aspect.performanceLog(joinPoint, dao, annotations[0]);
+
+        assertNotNull("Expected non-null result type", result);
+        assertTrue("Expected boolean return type from aspect, was " + result.getClass().getName(), result instanceof Boolean);
+        verify(gaugeService).submit(eq("timer.UserDaoHystrix.userExists"), anyLong());
+    }
+
+    @Test
+    public void testPerformanceLogSpringBootWithException() throws Throwable {
+        final UserDaoHystrix dao = new UserDaoHystrix();
+        final Method method = dao.getClass().getMethod("userExists", String.class);
+        final Timed[] annotations = method.getAnnotationsByType(Timed.class);
+
+        when(joinPoint.proceed()).thenThrow(IOException.class);
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.getName()).thenReturn("userExists");
+
+        final TimingAspect aspect = new TimingAspect(new MetricSinkSpringBoot(gaugeService));
+        IOException err = null;
+
+        try {
+            aspect.performanceLog(joinPoint, dao, annotations[0]);
+        } catch (IOException e) {
+            err = e;
+        }
+
+        assertNotNull("Expected exception to be raised while calling join point", err);
+        verify(gaugeService).submit(eq("timer.UserDaoHystrix.userExists"), anyLong());
     }
 }

--- a/src/test/java/com/smartertravel/metrics/aop/backend/MetricSinkSpringBootTest.java
+++ b/src/test/java/com/smartertravel/metrics/aop/backend/MetricSinkSpringBootTest.java
@@ -1,0 +1,34 @@
+package com.smartertravel.metrics.aop.backend;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.boot.actuate.metrics.GaugeService;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MetricSinkSpringBootTest {
+
+    @Mock
+    private GaugeService gaugeService;
+
+    @InjectMocks
+    private MetricSinkSpringBoot sink;
+
+    @Test
+    public void testTimeNativeUnit() {
+        this.sink.time("timer.someMetric", 4, TimeUnit.MILLISECONDS);
+        verify(gaugeService).submit("timer.someMetric", 4);
+    }
+
+    @Test
+    public void testTimeNanosUnit() {
+        this.sink.time("timer.someMetric", 2000000, TimeUnit.NANOSECONDS);
+        verify(gaugeService).submit("timer.someMetric", 2);
+    }
+}

--- a/src/test/java/com/smartertravel/metrics/aop/backend/MetricsSinkDropWizardTest.java
+++ b/src/test/java/com/smartertravel/metrics/aop/backend/MetricsSinkDropWizardTest.java
@@ -1,0 +1,37 @@
+package com.smartertravel.metrics.aop.backend;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MetricsSinkDropWizardTest {
+
+    @Mock
+    private MetricRegistry metricRegistry;
+
+    @Mock
+    private Timer timer;
+
+    @InjectMocks
+    private MetricSinkDropWizard sink;
+
+    @Test
+    public void testTimeDurationAndUnitPropagated() {
+        when(metricRegistry.timer(eq("timer.someKey"))).thenReturn(timer);
+
+        sink.time("timer.someKey", 100, TimeUnit.MILLISECONDS);
+
+        verify(timer).update(100, TimeUnit.MILLISECONDS);
+    }
+}


### PR DESCRIPTION
- Make DropWizard Metrics an optional metrics aggregation backend
- Make Spring Boot Actuator an optional metrics aggregation backend

This is largely done because Spring Boot 1.3 will be shipping with support
for pushing metrics to Statsd and JMX stores which was most of the reason
for using DropWizard in the first place.

By making each of the backends optional we don't force Spring applications
to use another lib for little benefit. We also don't force non-Spring
applications to pull in the entire world of Spring.

Fixes #2
