### PR TITLE
Move the "timer." prefix from TimingAspect to DefaultKeyGenerator.

### DIFF
--- a/src/site/markdown/changes.md
+++ b/src/site/markdown/changes.md
@@ -5,6 +5,11 @@ each release of the library are listed below along with an indication if they ar
 or not.
 
 
+### [v0.4.0](https://github.com//smarter-travel-media/st-metrics/tree/st-metrics-0.4.0) - 2016-08-01
+* **Breaking change** - Change `TimingAspect` and `DefaultKeyGenerator` to move the responsibility of
+  adding the `timer.` prefix to metrics from the aspect, to the key generator. Per
+  [#6](https://github.com/smarter-travel-media/st-metrics/issues/6).
+
 ### [v0.3.0](https://github.com//smarter-travel-media/st-metrics/tree/st-metrics-0.3.0) - 2016-03-25
 * Bump parent package to Spring Platform 2.0.1 (from 1.1.2) which in turns bumps the version of
   AspectJ, DropWizard, and Spring Boot Actuator pulled in.

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -188,7 +188,7 @@ public class MyAppKeyGenerator implements KeyGenerator {
 
     @Override
     public String getKey(JoinPoint jp, Object bean, Timed timed) {
-        return "myAwesomeApp." + bean.getClass().getSimpleName() + "." + jp.getSignature().getName();
+        return "timer.myAwesomeApp." + bean.getClass().getSimpleName() + "." + jp.getSignature().getName();
     }
 }
 ```

--- a/src/test/java/com/smartertravel/metrics/aop/TimingAspectTest.java
+++ b/src/test/java/com/smartertravel/metrics/aop/TimingAspectTest.java
@@ -75,7 +75,7 @@ public class TimingAspectTest {
         final Timed[] annotations = method.getAnnotationsByType(Timed.class);
 
         final DefaultKeyGenerator keyGenerator = new DefaultKeyGenerator();
-        assertEquals("mysqlDao.userExists", keyGenerator.getKey(joinPoint, dao, annotations[0]));
+        assertEquals("timer.mysqlDao.userExists", keyGenerator.getKey(joinPoint, dao, annotations[0]));
     }
 
     @Test
@@ -88,7 +88,7 @@ public class TimingAspectTest {
         when(signature.getName()).thenReturn("userExists");
 
         final DefaultKeyGenerator keyGenerator = new DefaultKeyGenerator();
-        assertEquals("UserDaoHystrix.userExists", keyGenerator.getKey(joinPoint, dao, annotations[0]));
+        assertEquals("timer.UserDaoHystrix.userExists", keyGenerator.getKey(joinPoint, dao, annotations[0]));
     }
 
     @Test


### PR DESCRIPTION
Allow other implementations of KeyGenerators to not prefix all metrics with
"timer." since this was only required in Spring and DropWizard. The default
behavior stays the same since the prefix will still be created by the default
key generator.

Fixes #6
